### PR TITLE
print_toolchain_versions.sh: add xtensa newlibs

### DIFF
--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -100,6 +100,8 @@ for p in \
          arm-none-eabi \
          mips-mti-elf \
          riscv-none-embed \
+         xtensa-esp32-elf \
+         xtensa-lx106-elf \
          ; do
     printf "%23s: %s\n" "$p-newlib" "$(newlib_version ${p}-gcc)"
 done


### PR DESCRIPTION
### Contribution description

Adds newlib versions bundled with xtensa toolchains to the toolchain version print tool.

### Testing procedure

See #10674

### Issues/PRs references

Fixes #10674